### PR TITLE
build(deps): bump axios and @nestjs/common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,20 +3031,24 @@
       }
     },
     "@nestjs/common": {
-      "version": "7.6.18",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.6.18.tgz",
-      "integrity": "sha512-BUJQHNhWzwWOkS4Ryndzd4HTeRObcAWV2Fh+ermyo3q3xYQQzNoEWclJVL/wZec8AONELwIJ+PSpWI53VP0leg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.1.1.tgz",
+      "integrity": "sha512-qrrCnc7FwYzJDjGJTRdL68nULFV0dkEa1DTJgtR7nHXzwcJU8EC+9wfMkahQdyB7ZPAQNJSuyarwmbgVFFNoLg==",
       "requires": {
-        "axios": "0.21.1",
         "iterare": "1.2.1",
-        "tslib": "2.2.0",
-        "uuid": "8.3.2"
+        "tslib": "2.4.0",
+        "uuid": "9.0.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
@@ -10236,14 +10240,6 @@
       "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -14583,7 +14579,8 @@
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.2.8",
     "@mui/x-data-grid": "^5.5.1",
-    "@nestjs/common": "^7.0.0",
+    "@nestjs/common": "^9.1.1",
     "@nestjs/config": "^1.0.1",
     "@nestjs/core": "^7.6.18",
     "@nestjs/mapped-types": "*",


### PR DESCRIPTION
Removes [axios](https://github.com/axios/axios). It's no longer used after updating ancestor dependency [@nestjs/common](https://github.com/nestjs/nest). These dependencies need to be updated together.


Removes `axios`

Updates `@nestjs/common` from 7.6.18 to 9.1.1
- [Release notes](https://github.com/nestjs/nest/releases)
- [Commits](https://github.com/nestjs/nest/compare/v7.6.18...v9.1.1)

---
updated-dependencies:
- dependency-name: axios dependency-type: indirect
- dependency-name: "@nestjs/common" dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>